### PR TITLE
Add missing header in socket_wrapper.cpp

### DIFF
--- a/provider/server.hpp
+++ b/provider/server.hpp
@@ -285,10 +285,18 @@ std::basic_ostream<char_t, traits_t>& errnoText (
     static size_t const BUFFER_LEN = 256;
     char errorBuffer[BUFFER_LEN];
     int err = errno;
+#if ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE)
+    int ret = strerror_r (err, errorBuffer, BUFFER_LEN);
+    if (ret != 0)
+        *errorBuffer = '\0';
+    strm << errorBuffer;
+    return strm;
+#else
     char* pErrorText = strerror_r (err, errorBuffer, BUFFER_LEN);
     strm << pErrorText;
     errno = err;
     return strm;
+#endif
 }
 
 

--- a/provider/socket_wrapper.cpp
+++ b/provider/socket_wrapper.cpp
@@ -4,6 +4,7 @@
 
 
 #include "debug_tags.hpp"
+#include "server.hpp"
 
 
 #include <errno.h>
@@ -14,20 +15,6 @@
 
 namespace
 {
-
-
-template<typename char_t, typename traits_t>
-std::basic_ostream<char_t, traits_t>& errnoText (
-    std::basic_ostream<char_t, traits_t>& strm)
-{
-    static size_t const BUFFER_LEN = 256;
-    char errorBuffer[BUFFER_LEN];
-    int err = errno;
-    char* pErrorText = strerror_r (err, errorBuffer, BUFFER_LEN);
-    strm << pErrorText;
-    errno = err;
-    return strm;
-}
 
 
 }


### PR DESCRIPTION
Inside the socket_wrapper.cpp file there is a call to strerror_r
which raises an error. As a workaround, the fpermissive flag can
be used which will allow the code to compile even if it doesn't
conform the language rules.

The fpermissive compilation flag can be avoided by including string.h.