### PR TITLE
Fix all compiler warnings

### DIFF
--- a/omigen_py/py_gen.cpp
+++ b/omigen_py/py_gen.cpp
@@ -137,7 +137,7 @@ public:
     std::basic_ostream<CHAR_t, TRAITS>&
     to_stream (std::basic_ostream<CHAR_t, TRAITS>& strm) const
     {
-        if (MI_FLAG_ANY == m_Scope & MI_FLAG_ANY)
+        if (MI_FLAG_ANY == (m_Scope & MI_FLAG_ANY))
         {
             strm << "MI_FLAG_ANY";
         }

--- a/provider/mi_value.cpp
+++ b/provider/mi_value.cpp
@@ -780,13 +780,13 @@ operator == (
                 static_cast<scx::MI_Timestamp const*>(&lhs);
             scx::MI_Timestamp const* pRHS =
                 static_cast<scx::MI_Timestamp const*>(&rhs);
-            return pLHS->getYear () == pRHS->getYear () &&
+            return (pLHS->getYear () == pRHS->getYear () &&
                 pLHS->getMonth () == pRHS->getMonth () &&
                 pLHS->getDay () == pRHS->getDay () &&
                 pLHS->getHour () == pRHS->getHour () &&
                 pLHS->getMinute () == pRHS->getMinute () &&
                 pLHS->getSecond () == pRHS->getSecond () &&
-                pLHS->getMicroseconds () == pRHS->getMicroseconds () ||
+                pLHS->getMicroseconds () == pRHS->getMicroseconds ()) ||
                 pLHS->getUTC () == pRHS->getUTC ();
         }
         else

--- a/python/bookend_wrapper.cpp
+++ b/python/bookend_wrapper.cpp
@@ -70,7 +70,7 @@ BookEnd_wrapper_init (
 {
     //SCX_BOOKEND ("BookEnd_wrapper_init");
     int rval = 0;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "title",
         "subTitle",
         NULL
@@ -78,7 +78,7 @@ BookEnd_wrapper_init (
     char const* title = NULL;
     char const* subTitle = NULL;
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "z|z", KEYWORDS, &title, &subTitle))
+            args, keywords, "z|z", const_cast<char **>(KEYWORDS), &title, &subTitle))
     {
         BookEnd_wrapper* pBookEnd = reinterpret_cast<BookEnd_wrapper*>(pSelf);
         new (&(pBookEnd->m_BookEnd)) scx::BookEnd (title, subTitle);

--- a/python/client_wrapper.cpp
+++ b/python/client_wrapper.cpp
@@ -118,7 +118,7 @@ Client_Wrapper::init (
     std::ostringstream strm;
 #endif
     // parse the args
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "fd",
         "path",
         NULL
@@ -126,7 +126,7 @@ Client_Wrapper::init (
     int fd = socket_wrapper::INVALID_SOCKET;
     char const* path = NULL;
     if (!PyArg_ParseTupleAndKeywords (
-            args, keywords, "is", KEYWORDS, &fd, &path))
+            args, keywords, "is", const_cast<char **>(KEYWORDS), &fd, &path))
     {
         CLIENT_INIT_BOOKEND_PRINT ("PyArg_ParseTuple failed");
         PyErr_SetString (PyExc_ValueError,
@@ -150,7 +150,7 @@ Client_Wrapper::init (
     // set the new path
     if (0 == rval)
     {
-        PyObject* pSysPath = PySys_GetObject ("path");
+        PyObject* pSysPath = PySys_GetObject (const_cast<char *>("path"));
         PyObjPtr pNewPathItem (PyString_FromString (path));
         if (NULL == pSysPath ||
             0 > PyList_Append (pSysPath, pNewPathItem.release ()))

--- a/python/mi_context_wrapper.cpp
+++ b/python/mi_context_wrapper.cpp
@@ -186,13 +186,13 @@ MI_Context_Wrapper::postResult (
     SCX_BOOKEND ("MI_Context_Wrapper::postResult");
     PyObject* pRet = NULL;
     // parse the args
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "result",
         NULL
     };
     MI_Uint32 resultAsUInt;
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "I", KEYWORDS, &resultAsUInt))
+            args, keywords, "I", const_cast<char **>(KEYWORDS), &resultAsUInt))
     {
         SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         MI_Result result;
@@ -237,13 +237,13 @@ MI_Context_Wrapper::postInstance (
     SCX_BOOKEND ("MI_Context_Wrapper::postInstance");
     PyObject* pRet = NULL;
     // parse the args
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "instance",
         NULL
     };
     PyObject* pInstanceObj = NULL;
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "O", KEYWORDS, &pInstanceObj))
+            args, keywords, "O", const_cast<char **>(KEYWORDS), &pInstanceObj))
     {
         SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         if (PyObject_TypeCheck (
@@ -293,12 +293,12 @@ MI_Context_Wrapper::newInstance (
 {
     SCX_BOOKEND ("MI_Context_Wrapper::newInstance");
     PyObject* rval = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "name",
         NULL
     };
     PyObject* pNameObj = NULL;
-    if (PyArg_ParseTupleAndKeywords (args, keywords, "O", KEYWORDS, &pNameObj))
+    if (PyArg_ParseTupleAndKeywords (args, keywords, "O", const_cast<char **>(KEYWORDS), &pNameObj))
     {
         MI_Type<MI_STRING>::type_t name;
         int ret = fromPyObject (pNameObj, &name);
@@ -357,7 +357,7 @@ MI_Context_Wrapper::newParameters (
 {
     SCX_BOOKEND ("MI_Context_Wrapper::newParameters");
     PyObject* rval = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "className",
         "methodName",
         NULL
@@ -365,7 +365,7 @@ MI_Context_Wrapper::newParameters (
     PyObject* pClassNameObj = NULL;
     PyObject* pMethodNameObj = NULL;
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "OO", KEYWORDS, &pClassNameObj, &pMethodNameObj))
+            args, keywords, "OO", const_cast<char **>(KEYWORDS), &pClassNameObj, &pMethodNameObj))
     {
         MI_Type<MI_STRING>::type_t className;
         int ret = fromPyObject (pClassNameObj, &className);

--- a/python/mi_function_table_placeholder.cpp
+++ b/python/mi_function_table_placeholder.cpp
@@ -597,7 +597,7 @@ MI_FunctionTable_Placeholder::init (
     PyObject* keywords)
 {
     SCX_BOOKEND ("MI_FunctionTable_Placeholder::init");
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "Load",
         "Unload",
         "GetInstance",
@@ -630,7 +630,7 @@ MI_FunctionTable_Placeholder::init (
     PyObject* pUnsubscribeObj = NULL;
     PyObject* pInvokeObj = NULL;
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "OOOOOOO|OOOOOOO", KEYWORDS, &pLoadObj, &pUnloadObj,
+            args, keywords, "OOOOOOO|OOOOOOO", const_cast<char **>(KEYWORDS), &pLoadObj, &pUnloadObj,
             &pGetInstanceObj, &pEnumerateInstancesObj, &pCreateInstanceObj,
             &pModifyInstanceObj, &pDeleteInstanceObj, &pAssociatorInstancesObj,
             &pReferenceInstancesObj, &pEnableIndicationsObj,

--- a/python/mi_instance_wrapper.cpp
+++ b/python/mi_instance_wrapper.cpp
@@ -817,10 +817,10 @@ MI_Instance_Wrapper::init (
     MI_Instance_Wrapper* pInstance =
         reinterpret_cast<MI_Instance_Wrapper*>(pSelf);
     pInstance->ctor (MI_Instance::Ptr (new MI_Instance (MI_ClassDecl::Ptr ())));
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         NULL
     };
-    if (PyArg_ParseTupleAndKeywords (args, keywords, "", KEYWORDS))
+    if (PyArg_ParseTupleAndKeywords (args, keywords, "", const_cast<char **>(KEYWORDS)))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         rval = PY_SUCCESS;
@@ -842,12 +842,12 @@ MI_Instance_Wrapper::getValue (
 {
     //SCX_BOOKEND ("MI_Instance_Wrapper::getValue");
     PyObject* rval = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "name",
         NULL
     };
     PyObject* pNameObj = NULL;
-    if (PyArg_ParseTupleAndKeywords (args, keywords, "O", KEYWORDS, &pNameObj))
+    if (PyArg_ParseTupleAndKeywords (args, keywords, "O", const_cast<char **>(KEYWORDS), &pNameObj))
     {
         MI_Type<MI_STRING>::type_t name;
         int ret = fromPyObject (pNameObj, &name);
@@ -1003,14 +1003,14 @@ MI_Instance_Wrapper::setValue (
 {
     //SCX_BOOKEND ("MI_Instance_Wrapper::setValue");
     PyObject* rval = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "name",
         "value",
         NULL
     };
     PyObject* pNameObj = NULL;
     PyObject* pValueObj = NULL;
-    if (PyArg_ParseTupleAndKeywords (args, keywords, "OO", KEYWORDS,
+    if (PyArg_ParseTupleAndKeywords (args, keywords, "OO", const_cast<char **>(KEYWORDS),
                                      &pNameObj, &pValueObj))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");

--- a/python/mi_module_wrapper.cpp
+++ b/python/mi_module_wrapper.cpp
@@ -99,7 +99,7 @@ MI_Module_Wrapper::init (
     PyObject* keywords)
 {
     SCX_BOOKEND ("MI_Module_Wrapper::init");
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "schemaDecl",
         "load",
         "unload",
@@ -110,7 +110,7 @@ MI_Module_Wrapper::init (
     PyObject* pLoadObj = NULL;
     PyObject* pUnloadObj = NULL;
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "OOO", KEYWORDS,
+            args, keywords, "OOO", const_cast<char **>(KEYWORDS),
             &pSchemaDeclObj, &pLoadObj, &pUnloadObj))
     {
         SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");

--- a/python/mi_schema_wrapper.cpp
+++ b/python/mi_schema_wrapper.cpp
@@ -349,7 +349,7 @@ MI_QualifierDecl_Wrapper::init (
     PyObject* keywords)
 {
     SCX_BOOKEND ("MI_QualifierDecl_Wrapper::init");
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "name",
         "type",
         "scope",
@@ -364,7 +364,7 @@ MI_QualifierDecl_Wrapper::init (
     PyObject* pFlavorObj = NULL;
     PyObject* pValueObj = NULL;
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "OOOO|O", KEYWORDS,
+            args, keywords, "OOOO|O", const_cast<char **>(KEYWORDS),
             &pNameObj, &pTypeObj, &pScopeObj, &pFlavorObj, &pValueObj))
     {
         MI_Value<MI_STRING>::Ptr pName;
@@ -523,7 +523,7 @@ MI_Qualifier_Wrapper::init (
     PyObject* keywords)
 {
     SCX_BOOKEND ("MI_Qualifier_Wrapper::init");
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "name",
         "type",
         "flavor",
@@ -536,7 +536,7 @@ MI_Qualifier_Wrapper::init (
     PyObject* pFlavorObj = NULL;
     PyObject* pValueObj = NULL;
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "OOOO|O", KEYWORDS,
+            args, keywords, "OOOO|O", const_cast<char **>(KEYWORDS),
             &pNameObj, &pTypeObj, &pFlavorObj, &pValueObj))
     {
         MI_Value<MI_STRING>::Ptr pName;
@@ -684,7 +684,7 @@ MI_PropertyDecl_Wrapper::init (
     PyObject* keywords)
 {
     SCX_BOOKEND ("MI_PropertyDecl_Wrapper::init");
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "flags",
         "name",
         "qualifiers",
@@ -705,7 +705,7 @@ MI_PropertyDecl_Wrapper::init (
     PyObject* pPropagatorObj = NULL;
     PyObject* pValueObj = NULL;
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "OOOOO|OOO", KEYWORDS,
+            args, keywords, "OOOOO|OOO", const_cast<char **>(KEYWORDS),
             &pFlagsObj, &pNameObj, &pQualifiersObj, &pTypeObj, &pClassNameObj,
             &pOriginObj, &pPropagatorObj, &pValueObj))
     {
@@ -907,7 +907,7 @@ MI_ParameterDecl_Wrapper::init (
     PyObject* keywords)
 {
     SCX_BOOKEND ("MI_ParameterDecl_Wrapper::init");
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "flags",
         "name",
         "qualifiers",
@@ -922,7 +922,7 @@ MI_ParameterDecl_Wrapper::init (
     PyObject* pTypeObj = NULL;
     PyObject* pClassNameObj = NULL;
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "OOOOO", KEYWORDS, 
+            args, keywords, "OOOOO", const_cast<char **>(KEYWORDS),
             &pFlagsObj, &pNameObj, &pQualifiersObj, &pTypeObj, &pClassNameObj))
     {
         MI_Value<MI_UINT32>::Ptr pFlags;
@@ -1086,7 +1086,7 @@ MI_MethodDecl_Placeholder::init (
     PyObject* keywords)
 {
     SCX_BOOKEND ("MI_MethodDecl_Placeholder::init");
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "flags",
         "name",
         "qualifiers",
@@ -1107,7 +1107,7 @@ MI_MethodDecl_Placeholder::init (
     PyObject* pPropagatorObj = NULL;
     PyObject* pInvokeFnNameObj = NULL;
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "OOOOOOOO", KEYWORDS,
+            args, keywords, "OOOOOOOO", const_cast<char **>(KEYWORDS),
             &pFlagsObj, &pNameObj, &pQualifiersObj, &pParametersObj,
             &pReturnTypeObj, &pOriginObj, &pPropagatorObj, &pInvokeFnNameObj))
     {
@@ -1339,7 +1339,7 @@ MI_ClassDecl_Placeholder::init (
     PyObject* keywords)
 {
     SCX_BOOKEND ("MI_ClassDecl_Placeholder::init");
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "flags",
         "name",
         "qualifiers",
@@ -1360,7 +1360,7 @@ MI_ClassDecl_Placeholder::init (
     PyObject* pFunctionTableObj = NULL;
     PyObject* pOwningClassNameObj = NULL;
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "OOOOOOOO", KEYWORDS,
+            args, keywords, "OOOOOOOO", const_cast<char **>(KEYWORDS),
             &pFlagsObj, &pNameObj, &pQualifiersObj, &pPropertyDeclsObj,
             &pSuperClassNameObj, &pMethodDeclsObj, &pFunctionTableObj,
             &pOwningClassNameObj))
@@ -1643,7 +1643,7 @@ MI_SchemaDecl_Placeholder::init (
     PyObject* keywords)
 {
     SCX_BOOKEND ("MI_SchemaDecl_Placeholder::init");
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "qualifierDecls",
         "classDecls",
         NULL
@@ -1652,7 +1652,7 @@ MI_SchemaDecl_Placeholder::init (
     PyObject* pQualifierDeclsObj = NULL;
     PyObject* pClassDeclsObj = NULL;
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "OO", KEYWORDS,
+            args, keywords, "OO", const_cast<char **>(KEYWORDS),
             &pQualifierDeclsObj, &pClassDeclsObj))
     {
         std::vector<MI_QualifierDecl_Wrapper::ValuePtr> qualifierDecls;

--- a/python/mi_wrapper.cpp
+++ b/python/mi_wrapper.cpp
@@ -254,10 +254,10 @@ template<> char const MI_Wrapper<_TYPE_>::NAME[] = #_NAME_; \
 template<> char const MI_Wrapper<_TYPE_>::OMI_NAME[] = "omi." #_NAME_; \
 template<> char const MI_Wrapper<_TYPE_>::DOC[] = "omi." #_NAME_ " utility"; \
 template<> PyGetSetDef MI_Wrapper<_TYPE_>::s_Mutators[] = { \
-   { "value", \
+   { const_cast<char *>("value"), \
      reinterpret_cast<getter>(_getValue), \
      reinterpret_cast<setter>(_setValue), \
-     "value type", \
+     const_cast<char *>("value type"), \
      NULL }, \
    { NULL }, \
 }; \
@@ -321,10 +321,10 @@ template<> char const MI_Array_Iterator<_TYPE_>::OMI_NAME[] = \
 template<> char const MI_Array_Iterator<_TYPE_>::DOC[] = \
     "iterator for omi." #_NAME_; \
 template<> PyGetSetDef MI_Array_Iterator<_TYPE_>::s_Mutators[] = { \
-   { "value", \
+   { const_cast<char *>("value"), \
      reinterpret_cast<getter>(_getValue), \
      reinterpret_cast<setter>(_setValue), \
-     "value type", \
+     const_cast<char *>("value type"), \
      NULL }, \
    { NULL }, \
 }; \
@@ -386,10 +386,10 @@ char const MI_Array_Iterator<MI_DATETIMEA>::OMI_NAME[] =
 char const MI_Array_Iterator<MI_DATETIMEA>::DOC[] =
     "iterator for omi.MI_DatetimeA";
 PyGetSetDef MI_Array_Iterator<MI_DATETIMEA>::s_Mutators[] = {
-   { "value",
+   { const_cast<char *>("value"),
      reinterpret_cast<getter>(_getValue),
      reinterpret_cast<setter>(_setValue),
-     "value type",
+     const_cast<char *>("value type"),
      NULL },
    { NULL },
 };
@@ -410,12 +410,12 @@ MI_Wrapper<MI_BOOLEAN>::init (
         reinterpret_cast<MI_Wrapper<MI_BOOLEAN>*>(pSelf);
     pWrapper->ctor (MI_Value<MI_BOOLEAN>::Ptr ());
     PyObject* pValue = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "value",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "|O", KEYWORDS, &pValue))
+            args, keywords, "|O", const_cast<char **>(KEYWORDS), &pValue))
     {
         if (NULL == pValue ||
             Py_None == pValue)
@@ -604,45 +604,45 @@ MI_Wrapper<MI_UINT8>::to_str (
 
 
 /*static*/ PyGetSetDef MI_Timestamp_Wrapper::MUTATORS[] = {
-    { "year",
+    { const_cast<char *>("year"),
       reinterpret_cast<getter>(_getYear),
       reinterpret_cast<setter>(_setYear),
-      "year value",
+      const_cast<char *>("year value"),
       NULL },
-    { "month",
+    { const_cast<char *>("month"),
       reinterpret_cast<getter>(_getMonth),
       reinterpret_cast<setter>(_setMonth),
-      "month value",
+      const_cast<char *>("month value"),
       NULL },
-    { "day",
+    { const_cast<char *>("day"),
       reinterpret_cast<getter>(_getDay),
       reinterpret_cast<setter>(_setDay),
-      "day value",
+      const_cast<char *>("day value"),
       NULL },
-    { "hour",
+    { const_cast<char *>("hour"),
       reinterpret_cast<getter>(_getHour),
       reinterpret_cast<setter>(_setHour),
-      "hour value",
+      const_cast<char *>("hour value"),
       NULL },
-    { "minute",
+    { const_cast<char *>("minute"),
       reinterpret_cast<getter>(_getMinute),
       reinterpret_cast<setter>(_setMinute),
-      "minute value",
+      const_cast<char *>("minute value"),
       NULL },
-    { "second",
+    { const_cast<char *>("second"),
       reinterpret_cast<getter>(_getSecond),
       reinterpret_cast<setter>(_setSecond),
-      "second value",
+      const_cast<char *>("second value"),
       NULL },
-    { "microseconds",
+    { const_cast<char *>("microseconds"),
       reinterpret_cast<getter>(_getMicroseconds),
       reinterpret_cast<setter>(_setMicroseconds),
-      "microseconds value",
+      const_cast<char *>("microseconds value"),
       NULL },
-    { "utc",
+    { const_cast<char *>("utc"),
       reinterpret_cast<getter>(_getUTC),
       reinterpret_cast<setter>(_setUTC),
-      "utc value",
+      const_cast<char *>("utc value"),
       NULL },
     { NULL },
 };
@@ -720,7 +720,7 @@ MI_Timestamp_Wrapper::init (
     PyObject* pSecondObj = NULL;
     PyObject* pMicrosecondsObj = NULL;
     PyObject* pUtcObj = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "year",
         "month",
         "day",
@@ -732,7 +732,7 @@ MI_Timestamp_Wrapper::init (
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "|OOOOOOOO", KEYWORDS, &pYearObj, &pMonthObj,
+            args, keywords, "|OOOOOOOO", const_cast<char **>(KEYWORDS), &pYearObj, &pMonthObj,
             &pDayObj, &pHourObj, &pMinuteObj, &pSecondObj, &pMicrosecondsObj,
             &pUtcObj))
     {
@@ -1182,30 +1182,30 @@ MI_Timestamp_Wrapper::getValue () const
 
 
 /*static*/ PyGetSetDef MI_Interval_Wrapper::MUTATORS[] = {
-    { "days",
+    { const_cast<char *>("days"),
       reinterpret_cast<getter>(_getDays),
       reinterpret_cast<setter>(_setDays),
-      "days value",
+      const_cast<char *>("days value"),
       NULL },
-    { "hours",
+    { const_cast<char *>("hours"),
       reinterpret_cast<getter>(_getHours),
       reinterpret_cast<setter>(_setHours),
-      "hours value",
+      const_cast<char *>("hours value"),
       NULL },
-    { "minutes",
+    { const_cast<char *>("minutes"),
       reinterpret_cast<getter>(_getMinutes),
       reinterpret_cast<setter>(_setMinutes),
-      "minutes value",
+      const_cast<char *>("minutes value"),
       NULL },
-    { "seconds",
+    { const_cast<char *>("seconds"),
       reinterpret_cast<getter>(_getSeconds),
       reinterpret_cast<setter>(_setSeconds),
-      "seconds value",
+      const_cast<char *>("seconds value"),
       NULL },
-    { "microseconds",
+    { const_cast<char *>("microseconds"),
       reinterpret_cast<getter>(_getMicroseconds),
       reinterpret_cast<setter>(_setMicroseconds),
-      "microseconds value",
+      const_cast<char *>("microseconds value"),
       NULL },
     { NULL },
 };
@@ -1312,7 +1312,7 @@ MI_Interval_Wrapper::init (
     PyObject* pMinutesObj = NULL;
     PyObject* pSecondsObj = NULL;
     PyObject* pMicrosecondsObj = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "days",
         "hours",
         "minutes",
@@ -1321,7 +1321,7 @@ MI_Interval_Wrapper::init (
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "|OOOOO", KEYWORDS, &pDaysObj, &pHoursObj,
+            args, keywords, "|OOOOO", const_cast<char **>(KEYWORDS), &pDaysObj, &pHoursObj,
             &pMinutesObj, &pSecondsObj, &pMicrosecondsObj))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
@@ -1991,12 +1991,12 @@ MI_Array_Wrapper<MI_DATETIMEA>::init (
         reinterpret_cast<MI_Array_Wrapper<MI_DATETIMEA>*>(pSelf);
     pWrapper->ctor ();
     PyObject* pValue = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "values",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "|O", KEYWORDS, &pValue))
+            args, keywords, "|O", const_cast<char **>(KEYWORDS), &pValue))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         if (NULL == pValue)
@@ -2143,12 +2143,12 @@ MI_Array_Wrapper<MI_DATETIMEA>::_getValueAt (
     //SCX_BOOKEND ("MI_Array_Wrapper<MI_DATETIMEA>::_getValueAt");
     PyObject* pRval = NULL;
     long index = 0;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "index",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "l", KEYWORDS, &index))
+            args, keywords, "l", const_cast<char **>(KEYWORDS), &index))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         MI_Array_Wrapper<MI_DATETIMEA>* pArray =
@@ -2206,13 +2206,13 @@ MI_Array_Wrapper<MI_DATETIMEA>::_setValueAt (
     PyObject* rval = NULL;
     long index = 0;
     PyObject* pValueObj = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "index",
         "value",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "lO", KEYWORDS, &index, &pValueObj))
+            args, keywords, "lO", const_cast<char **>(KEYWORDS), &index, &pValueObj))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         MI_Array_Wrapper<MI_DATETIMEA>* pArray =
@@ -2281,12 +2281,12 @@ MI_Array_Wrapper<MI_DATETIMEA>::_append (
     SCX_BOOKEND ("MI_Array_Wrapper<MI_DATETIMEA>::_append");
     PyObject* rval = NULL;
     PyObject* pValueObj = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "value",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "O", KEYWORDS, &pValueObj))
+            args, keywords, "O", const_cast<char **>(KEYWORDS), &pValueObj))
     {
         SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         MI_Array_Wrapper<MI_DATETIMEA>* pArray =
@@ -2339,13 +2339,13 @@ MI_Array_Wrapper<MI_DATETIMEA>::_insert (
     PyObject* rval = NULL;
     long index = 0;;
     PyObject* pValueObj = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "index",
         "value",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "lO", KEYWORDS, &index, &pValueObj))
+            args, keywords, "lO", const_cast<char **>(KEYWORDS), &index, &pValueObj))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         MI_Array_Wrapper<MI_DATETIMEA>* pArray =
@@ -2414,12 +2414,12 @@ MI_Array_Wrapper<MI_DATETIMEA>::_pop (
     MI_Array_Wrapper<MI_DATETIMEA>* pArray =
         reinterpret_cast<MI_Array_Wrapper<MI_DATETIMEA>*>(pSelf);
     long index = static_cast<long>(pArray->m_pArray->size ()) - 1;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "index",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "|l", KEYWORDS, &index))
+            args, keywords, "|l", const_cast<char **>(KEYWORDS), &index))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         if (0 > index)
@@ -2569,12 +2569,12 @@ MI_Array_Wrapper<MI_BOOLEANA>::init (
         reinterpret_cast<MI_Array_Wrapper<MI_BOOLEANA>*>(pSelf);
     pWrapper->ctor ();
     PyObject* pValue = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "values",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "|O", KEYWORDS, &pValue))
+            args, keywords, "|O", const_cast<char **>(KEYWORDS), &pValue))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         if (NULL == pValue)
@@ -2670,12 +2670,12 @@ MI_Array_Wrapper<MI_BOOLEANA>::_getValueAt (
     //SCX_BOOKEND ("MI_Array_Wrapper<MI_BOOLEANA>::_getValueAt");
     PyObject* pRval = NULL;
     long index = 0;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "index",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "l", KEYWORDS, &index))
+            args, keywords, "l", const_cast<char **>(KEYWORDS), &index))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         MI_Array_Wrapper<MI_BOOLEANA>* pArray =
@@ -2717,13 +2717,13 @@ MI_Array_Wrapper<MI_BOOLEANA>::_setValueAt (
     PyObject* rval = NULL;
     long index = 0;
     PyObject* pValueObj = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "index",
         "value",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "lO", KEYWORDS, &index, &pValueObj))
+            args, keywords, "lO", const_cast<char **>(KEYWORDS), &index, &pValueObj))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         MI_Array_Wrapper<MI_BOOLEANA>* pArray =
@@ -2777,12 +2777,12 @@ MI_Array_Wrapper<MI_BOOLEANA>::_append (
     //SCX_BOOKEND ("MI_Array_Wrapper<MI_BOOLEANA>::_append");
     PyObject* rval = NULL;
     PyObject* pValueObj = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "value",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "O", KEYWORDS, &pValueObj))
+            args, keywords, "O", const_cast<char **>(KEYWORDS), &pValueObj))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         MI_Array_Wrapper<MI_BOOLEANA>* pArray =
@@ -2824,13 +2824,13 @@ MI_Array_Wrapper<MI_BOOLEANA>::_insert (
     PyObject* rval = NULL;
     long index = 0;;
     PyObject* pValueObj = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "index",
         "value",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "lO", KEYWORDS, &index, &pValueObj))
+            args, keywords, "lO", const_cast<char **>(KEYWORDS), &index, &pValueObj))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         MI_Array_Wrapper<MI_BOOLEANA>* pArray =
@@ -2886,12 +2886,12 @@ MI_Array_Wrapper<MI_BOOLEANA>::_pop (
     MI_Array_Wrapper<MI_BOOLEANA>* pArray =
         reinterpret_cast<MI_Array_Wrapper<MI_BOOLEANA>*>(pSelf);
     long index = static_cast<long>(pArray->m_pArray->size ()) - 1;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "index",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "|l", KEYWORDS, &index))
+            args, keywords, "|l", const_cast<char **>(KEYWORDS), &index))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         if (0 > index)
@@ -3115,12 +3115,12 @@ MI_PropertySet_Wrapper::_ContainsElement (
     //SCX_BOOKEND ("MI_PropertySet_Wrapper::_ContainsElement");
     PyObject* rval = NULL;
     PyObject* pKeyObj = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "key",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "O", KEYWORDS, &pKeyObj))
+            args, keywords, "O", const_cast<char **>(KEYWORDS), &pKeyObj))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         MI_Type<MI_STRING>::type_t key;
@@ -3157,12 +3157,12 @@ MI_PropertySet_Wrapper::_GetElementAt (
     SCX_BOOKEND ("MI_PropertySet_Wrapper::_GetElementAt");
     MI_Wrapper<MI_STRING>::PyPtr rval;
     long index = 0;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "index",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "l", KEYWORDS, &index))
+            args, keywords, "l", const_cast<char **>(KEYWORDS), &index))
     {
         SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         MI_PropertySet_Wrapper* pPropertySet =

--- a/python/mi_wrapper.hpp
+++ b/python/mi_wrapper.hpp
@@ -622,12 +622,12 @@ MI_Wrapper<TYPE_ID>::init (
         reinterpret_cast<MI_Wrapper<TYPE_ID>*>(pSelf);
     pWrapper->ctor (typename MI_Value<TYPE_ID>::Ptr ());
     PyObject* pValue = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "value",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "|O", KEYWORDS, &pValue))
+            args, keywords, "|O", const_cast<char **>(KEYWORDS), &pValue))
     {
         if (NULL == pValue ||
             Py_None == pValue)
@@ -915,12 +915,12 @@ MI_Array_Wrapper<TYPE_ID>::init (
         reinterpret_cast<MI_Array_Wrapper<TYPE_ID>*>(pSelf);
     pWrapper->ctor ();
     PyObject* pValue = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "values",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "|O", KEYWORDS, &pValue))
+            args, keywords, "|O", const_cast<char **>(KEYWORDS), &pValue))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         if (NULL == pValue)
@@ -1045,12 +1045,12 @@ MI_Array_Wrapper<TYPE_ID>::_getValueAt (
     //SCX_BOOKEND ("MI_Array_Wrapper::_getValueAt");
     PyObject* pRval = NULL;
     long index = 0;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "index",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "l", KEYWORDS, &index))
+            args, keywords, "l", const_cast<char **>(KEYWORDS), &index))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         MI_Array_Wrapper<TYPE_ID>* pArray =
@@ -1098,13 +1098,13 @@ MI_Array_Wrapper<TYPE_ID>::_setValueAt (
     PyObject* rval = NULL;
     long index = 0;
     PyObject* pValueObj = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "index",
         "value",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "lO", KEYWORDS, &index, &pValueObj))
+            args, keywords, "lO", const_cast<char **>(KEYWORDS), &index, &pValueObj))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         MI_Array_Wrapper<TYPE_ID>* pArray =
@@ -1162,12 +1162,12 @@ MI_Array_Wrapper<TYPE_ID>::_append (
     //SCX_BOOKEND ("MI_Array_Wrapper::_append");
     PyObject* rval = NULL;
     PyObject* pValueObj = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "value",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "O", KEYWORDS, &pValueObj))
+            args, keywords, "O", const_cast<char **>(KEYWORDS), &pValueObj))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         MI_Array_Wrapper<TYPE_ID>* pArray =
@@ -1213,13 +1213,13 @@ MI_Array_Wrapper<TYPE_ID>::_insert (
     PyObject* rval = NULL;
     long index = 0;;
     PyObject* pValueObj = NULL;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "index",
         "value",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "lO", KEYWORDS, &index, &pValueObj))
+            args, keywords, "lO", const_cast<char **>(KEYWORDS), &index, &pValueObj))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         MI_Array_Wrapper<TYPE_ID>* pArray =
@@ -1279,12 +1279,12 @@ MI_Array_Wrapper<TYPE_ID>::_pop (
     MI_Array_Wrapper<TYPE_ID>* pArray =
         reinterpret_cast<MI_Array_Wrapper<TYPE_ID>*>(pSelf);
     long index = static_cast<long>(pArray->m_pArray->size ()) - 1;
-    char* KEYWORDS[] = {
+    char const* KEYWORDS[] = {
         "index",
         NULL
     };
     if (PyArg_ParseTupleAndKeywords (
-            args, keywords, "|l", KEYWORDS, &index))
+            args, keywords, "|l", const_cast<char **>(KEYWORDS), &index))
     {
         //SCX_BOOKEND_PRINT ("PyArg_ParseTupleAndKeywords succeeded");
         if (0 > index)

--- a/python/omi_module.cpp
+++ b/python/omi_module.cpp
@@ -18,12 +18,6 @@
 namespace {
 
 
-char* KEYWORDS[] = {
-    "name",
-    NULL
-};
-
-
 PyMethodDefContainer_t g_methods;
 
 

--- a/test/internal_counted_ptr_test.cpp
+++ b/test/internal_counted_ptr_test.cpp
@@ -3873,10 +3873,14 @@ internal_counted_ptr_test::test55 ()
     {
         util::internal_counted_ptr<BaseType> pBase;
         util::default_delete<BaseType> deleter = pBase.get_deleter ();
+        // To surpress the unused variable warning
+        (void)deleter;
     }
     {
         util::internal_counted_ptr<BaseType, BaseDeleter> pBase;
         BaseDeleter deleter = pBase.get_deleter ();
+        // To surpress the unused variable warning
+        (void)deleter;
     }
     {
         util::internal_counted_ptr<BaseType, void (*)(BaseType*&)> pBase (

--- a/test/mi_memory_helper_test.cpp
+++ b/test/mi_memory_helper_test.cpp
@@ -955,7 +955,7 @@ mi_memory_helper_test::test11 ()
     };
     MI_StringA stringA = {
         new MI_Char*[card (TEST_STRINGS)],
-        card (TEST_STRINGS)
+        (unsigned int)card (TEST_STRINGS)
     };
     for (size_t i = 0; i < card (TEST_STRINGS); ++i)
     {
@@ -1007,7 +1007,7 @@ mi_memory_helper_test::test12 ()
     }
     MI_StringA stringA = {
         new MI_Char*[card (TEST_STRINGS)],
-        card (TEST_STRINGS)
+        (unsigned int)card (TEST_STRINGS)
     };
     for (size_t i = 0; i < card (TEST_STRINGS); ++i)
     {
@@ -1059,7 +1059,7 @@ mi_memory_helper_test::test13 ()
     }
     MI_StringA stringA = {
         new MI_Char*[card (TEST_STRINGS)],
-        card (TEST_STRINGS)
+        (unsigned int)card (TEST_STRINGS)
     };
     for (size_t i = 0; i < card (TEST_STRINGS); ++i)
     {
@@ -1111,7 +1111,7 @@ mi_memory_helper_test::test14 ()
     }
     MI_StringA stringA = {
         new MI_Char*[card (TEST_STRINGS)],
-        card (TEST_STRINGS)
+        (unsigned int)card (TEST_STRINGS)
     };
     for (size_t i = 0; i < card (TEST_STRINGS); ++i)
     {

--- a/test/shared_protocol_test.cpp
+++ b/test/shared_protocol_test.cpp
@@ -344,7 +344,7 @@ shared_protocol_test::test05 ()
     if (EXIT_SUCCESS == rval)
     {
         // test an empty string
-        MI_Char* pStrOut = "";
+        MI_Char* pStrOut = const_cast<char*>("");
         rval = protocol::send (pStrOut, *sendSock);
         if (EXIT_SUCCESS == rval)
         {

--- a/test/unique_ptr_test.cpp
+++ b/test/unique_ptr_test.cpp
@@ -2205,10 +2205,14 @@ unique_ptr_test::test30 ()
     {
         util::unique_ptr<BaseType> pBase;
         util::default_delete<BaseType> deleter = pBase.get_deleter ();
+        // To surpress the unused variable warning
+        (void)deleter;
     }
     {
         util::unique_ptr<BaseType, BaseDeleter> pBase;
         BaseDeleter deleter = pBase.get_deleter ();
+        // To surpress the unused variable warning
+        (void)deleter;
     }
     {
         util::unique_ptr<BaseType, void (*)(BaseType*&)> pBase (
@@ -4614,10 +4618,14 @@ unique_ptr_test::test68 ()
     {
         util::unique_ptr<BaseType[]> pBase;
         util::default_delete<BaseType[]> deleter = pBase.get_deleter ();
+        // To surpress the unused variable warning
+        (void)deleter;
     }
     {
         util::unique_ptr<BaseType[], ArrayDeleter> pBase;
         ArrayDeleter deleter = pBase.get_deleter ();
+        // To surpress the unused variable warning
+        (void)deleter;
     }
     {
         util::unique_ptr<BaseType[], void (*)(BaseType*&)> pBase (


### PR DESCRIPTION
In some cases, compiler warnings can be used to find
real issues in the code.

This commit fixes all the compiler warnings.