### PR TITLE
Add Python 3 support

### DIFF
--- a/python/bookend_wrapper.cpp
+++ b/python/bookend_wrapper.cpp
@@ -45,7 +45,7 @@ BookEnd_wrapper_dealloc (
     {
         BookEnd_wrapper* pBookEnd = reinterpret_cast<BookEnd_wrapper*>(pObj);
         pBookEnd->~BookEnd_wrapper ();
-        pBookEnd->ob_type->tp_free (pObj);
+        Py_TYPE(pBookEnd)->tp_free (pObj);
     }
 }
 

--- a/python/client_wrapper.cpp
+++ b/python/client_wrapper.cpp
@@ -5,6 +5,7 @@
 
 #include "debug_tags.hpp"
 #include "py_ptr.hpp"
+#include "python_compatibility.hpp"
 #include "shared.hpp"
 #include "mi_module_wrapper.hpp"
 
@@ -67,7 +68,7 @@ Client_Wrapper::dealloc (
         Client_Wrapper* pDecl =
             reinterpret_cast<Client_Wrapper*>(pObj);
         pDecl->~Client_Wrapper ();
-        pDecl->ob_type->tp_free (pObj);
+        Py_TYPE(pDecl)->tp_free (pObj);
     }
 }
 

--- a/python/mi_context_wrapper.cpp
+++ b/python/mi_context_wrapper.cpp
@@ -126,16 +126,16 @@ to_MI_Result (
 /*static*/ PyMethodDef MI_Context_Wrapper::METHODS[] = {
     { "PostResult",
       reinterpret_cast<PyCFunction>(MI_Context_Wrapper::postResult),
-      METH_KEYWORDS, "post a result to omi" },
+      METH_VARARGS | METH_KEYWORDS, "post a result to omi" },
     { "PostInstance",
       reinterpret_cast<PyCFunction>(MI_Context_Wrapper::postInstance),
-      METH_KEYWORDS, "return a MI_Instance to omi" },
+      METH_VARARGS | METH_KEYWORDS, "return a MI_Instance to omi" },
     { "NewInstance",
       reinterpret_cast<PyCFunction>(MI_Context_Wrapper::newInstance),
-      METH_KEYWORDS, "create a new MI_Instance" },
+      METH_VARARGS | METH_KEYWORDS, "create a new MI_Instance" },
     { "NewParameters",
       reinterpret_cast<PyCFunction>(MI_Context_Wrapper::newParameters),
-      METH_KEYWORDS, "create a new MI_Instance for method parameters" },
+      METH_VARARGS | METH_KEYWORDS, "create a new MI_Instance for method parameters" },
     { NULL, NULL, 0, NULL }
 };
 
@@ -172,7 +172,7 @@ MI_Context_Wrapper::dealloc (
         MI_Context_Wrapper* pDecl =
             reinterpret_cast<MI_Context_Wrapper*>(pObj);
         pDecl->~MI_Context_Wrapper ();
-        pDecl->ob_type->tp_free (pObj);
+        Py_TYPE(pDecl)->tp_free (pObj);
     }
 }
 

--- a/python/mi_function_table_placeholder.cpp
+++ b/python/mi_function_table_placeholder.cpp
@@ -566,7 +566,7 @@ MI_FunctionTable_Placeholder::dealloc (
         MI_FunctionTable_Placeholder* pDecl =
             reinterpret_cast<MI_FunctionTable_Placeholder*>(pObj);
         pDecl->~MI_FunctionTable_Placeholder ();
-        pDecl->ob_type->tp_free (pObj);
+        Py_TYPE(pDecl)->tp_free (pObj);
     }
 }
 

--- a/python/mi_instance_wrapper.cpp
+++ b/python/mi_instance_wrapper.cpp
@@ -730,10 +730,10 @@ convertToBase (
 /*static*/ PyMethodDef MI_Instance_Wrapper::METHODS[] = {
     { "GetValue",
       reinterpret_cast<PyCFunction>(MI_Instance_Wrapper::getValue),
-      METH_KEYWORDS, "retrieve a value from the instance" },
+      METH_VARARGS | METH_KEYWORDS, "retrieve a value from the instance" },
     { "SetValue",
       reinterpret_cast<PyCFunction>(MI_Instance_Wrapper::setValue),
-      METH_KEYWORDS, "set a value for the instance" },
+      METH_VARARGS | METH_KEYWORDS, "set a value for the instance" },
     { NULL, NULL, 0, NULL }
 };
 
@@ -772,7 +772,7 @@ MI_Instance_Wrapper::dealloc (
         MI_Instance_Wrapper* pDecl =
             reinterpret_cast<MI_Instance_Wrapper*>(pObj);
         pDecl->~MI_Instance_Wrapper ();
-        pDecl->ob_type->tp_free (pObj);
+        Py_TYPE(pDecl)->tp_free (pObj);
     }
 }
 

--- a/python/mi_module_wrapper.cpp
+++ b/python/mi_module_wrapper.cpp
@@ -75,7 +75,7 @@ MI_Module_Wrapper::dealloc (
         MI_Module_Wrapper* pDecl =
             reinterpret_cast<MI_Module_Wrapper*>(pObj);
         pDecl->~MI_Module_Wrapper ();
-        pDecl->ob_type->tp_free (pObj);
+        Py_TYPE(pDecl)->tp_free (pObj);
     }
 }
 

--- a/python/mi_schema_wrapper.cpp
+++ b/python/mi_schema_wrapper.cpp
@@ -318,7 +318,7 @@ MI_QualifierDecl_Wrapper::dealloc (
         MI_QualifierDecl_Wrapper* pDecl =
             reinterpret_cast<MI_QualifierDecl_Wrapper*>(pObj);
         pDecl->~MI_QualifierDecl_Wrapper ();
-        pDecl->ob_type->tp_free (pObj);
+        Py_TYPE(pDecl)->tp_free (pObj);
     }
 }
 
@@ -492,7 +492,7 @@ MI_Qualifier_Wrapper::dealloc (
         MI_Qualifier_Wrapper* pDecl =
             reinterpret_cast<MI_Qualifier_Wrapper*>(pObj);
         pDecl->~MI_Qualifier_Wrapper ();
-        pDecl->ob_type->tp_free (pObj);
+        Py_TYPE(pDecl)->tp_free (pObj);
     }
 }
 
@@ -653,7 +653,7 @@ MI_PropertyDecl_Wrapper::dealloc (
         MI_PropertyDecl_Wrapper* pDecl =
             reinterpret_cast<MI_PropertyDecl_Wrapper*>(pObj);
         pDecl->~MI_PropertyDecl_Wrapper ();
-        pDecl->ob_type->tp_free (pObj);
+        Py_TYPE(pDecl)->tp_free (pObj);
     }
 }
 
@@ -876,7 +876,7 @@ MI_ParameterDecl_Wrapper::dealloc (
         MI_ParameterDecl_Wrapper* pDecl =
             reinterpret_cast<MI_ParameterDecl_Wrapper*>(pObj);
         pDecl->~MI_ParameterDecl_Wrapper ();
-        pDecl->ob_type->tp_free (pObj);
+        Py_TYPE(pDecl)->tp_free (pObj);
     }
 }
 
@@ -1055,7 +1055,7 @@ MI_MethodDecl_Placeholder::dealloc (
         MI_MethodDecl_Placeholder* pDecl =
             reinterpret_cast<MI_MethodDecl_Placeholder*>(pObj);
         pDecl->~MI_MethodDecl_Placeholder ();
-        pDecl->ob_type->tp_free (pObj);
+        Py_TYPE(pDecl)->tp_free (pObj);
     }
 }
 
@@ -1308,7 +1308,7 @@ MI_ClassDecl_Placeholder::dealloc (
         MI_ClassDecl_Placeholder* pDecl =
             reinterpret_cast<MI_ClassDecl_Placeholder*>(pObj);
         pDecl->~MI_ClassDecl_Placeholder ();
-        pDecl->ob_type->tp_free (pObj);
+        Py_TYPE(pDecl)->tp_free (pObj);
     }
 }
 
@@ -1612,7 +1612,7 @@ MI_SchemaDecl_Placeholder::dealloc (
         MI_SchemaDecl_Placeholder* pDecl =
             reinterpret_cast<MI_SchemaDecl_Placeholder*>(pObj);
         pDecl->~MI_SchemaDecl_Placeholder ();
-        pDecl->ob_type->tp_free (pObj);
+        Py_TYPE(pDecl)->tp_free (pObj);
     }
 }
 

--- a/python/mi_wrapper.cpp
+++ b/python/mi_wrapper.cpp
@@ -15,6 +15,7 @@
 #include "mi_function_table_placeholder.hpp"
 #include "shared_protocol.hpp"
 #include "shared.hpp"
+#include "python_compatibility.hpp"
 
 
 using namespace scx;
@@ -301,18 +302,18 @@ template<> PyMethodDef MI_Array_Wrapper<_TYPE_>::METHODS[] = { \
       METH_NOARGS, "return item count" }, \
     { "getValueAt", \
       reinterpret_cast<PyCFunction>(MI_Array_Wrapper<_TYPE_>::_getValueAt), \
-      METH_KEYWORDS, "return value at index" }, \
+      METH_VARARGS | METH_KEYWORDS, "return value at index" }, \
     { "setValueAt", \
       reinterpret_cast<PyCFunction>(MI_Array_Wrapper<_TYPE_>::_setValueAt), \
-      METH_KEYWORDS, "set value at index" }, \
+      METH_VARARGS | METH_KEYWORDS, "set value at index" }, \
     { "append", \
       reinterpret_cast<PyCFunction>(MI_Array_Wrapper<_TYPE_>::_append), \
-      METH_KEYWORDS, "append value" }, \
+      METH_VARARGS | METH_KEYWORDS, "append value" }, \
     { "insert", \
       reinterpret_cast<PyCFunction>(MI_Array_Wrapper<_TYPE_>::_insert), \
-      METH_KEYWORDS, "insert value at index" }, \
+      METH_VARARGS | METH_KEYWORDS, "insert value at index" }, \
     { "pop", reinterpret_cast<PyCFunction>(MI_Array_Wrapper<_TYPE_>::_pop), \
-      METH_KEYWORDS, "remove value at index and return it" }, \
+      METH_VARARGS | METH_KEYWORDS, "remove value at index and return it" }, \
     { NULL, NULL, 0, NULL } \
 }; \
 template<> char const MI_Array_Iterator<_TYPE_>::NAME[] = #_NAME_ "_iterator"; \
@@ -364,20 +365,20 @@ PyMethodDef MI_Array_Wrapper<MI_DATETIMEA>::METHODS[] = {
     { "getValueAt",
       reinterpret_cast<PyCFunction>(
           MI_Array_Wrapper<MI_DATETIMEA>::_getValueAt),
-      METH_KEYWORDS, "return value at index" },
+      METH_VARARGS | METH_KEYWORDS, "return value at index" },
     { "setValueAt",
       reinterpret_cast<PyCFunction>(
           MI_Array_Wrapper<MI_DATETIMEA>::_setValueAt),
-      METH_KEYWORDS, "set value at index" },
+      METH_VARARGS | METH_KEYWORDS, "set value at index" },
     { "append",
       reinterpret_cast<PyCFunction>(MI_Array_Wrapper<MI_DATETIMEA>::_append),
-      METH_KEYWORDS, "append value" },
+      METH_VARARGS | METH_KEYWORDS, "append value" },
     { "insert",
       reinterpret_cast<PyCFunction>(MI_Array_Wrapper<MI_DATETIMEA>::_insert),
-      METH_KEYWORDS, "insert value at index" },
+      METH_VARARGS | METH_KEYWORDS, "insert value at index" },
     { "pop",
       reinterpret_cast<PyCFunction>(MI_Array_Wrapper<MI_DATETIMEA>::_pop),
-      METH_KEYWORDS, "remove value at index and return it" },
+      METH_VARARGS | METH_KEYWORDS, "remove value at index and return it" },
     { NULL, NULL, 0, NULL }
 };
 char const MI_Array_Iterator<MI_DATETIMEA>::NAME[] = "MI_DatetimeA_iterator";
@@ -699,7 +700,7 @@ MI_Timestamp_Wrapper::dealloc (
     MI_Timestamp_Wrapper* pTimestamp =
         reinterpret_cast<MI_Timestamp_Wrapper*>(pSelf);
     pTimestamp->dtor ();
-    pTimestamp->ob_type->tp_free (pSelf);
+    Py_TYPE(pTimestamp)->tp_free (pSelf);
 }
 
 
@@ -1294,7 +1295,7 @@ MI_Interval_Wrapper::dealloc (
     MI_Interval_Wrapper* pInterval =
         reinterpret_cast<MI_Interval_Wrapper*>(pSelf);
     pInterval->dtor ();
-    pInterval->ob_type->tp_free (pSelf);
+    Py_TYPE(pInterval)->tp_free (pSelf);
 }
 
 
@@ -1636,7 +1637,7 @@ MI_Array_Iterator<MI_DATETIMEA>::dealloc (
     MI_Array_Iterator<MI_DATETIMEA>* pArray =
         reinterpret_cast<MI_Array_Iterator<MI_DATETIMEA>*>(pObj);
     pArray->dtor ();
-    pArray->ob_type->tp_free (pObj);
+    Py_TYPE(pArray)->tp_free (pObj);
 }
 
 
@@ -1975,7 +1976,7 @@ MI_Array_Wrapper<MI_DATETIMEA>::dealloc (
     MI_Array_Wrapper<MI_DATETIMEA>* pArray =
         reinterpret_cast<MI_Array_Wrapper<MI_DATETIMEA>*>(pSelf);
     pArray->dtor ();
-    pArray->ob_type->tp_free (pSelf);
+    Py_TYPE(pArray)->tp_free (pSelf);
 }
 
 
@@ -3049,7 +3050,7 @@ MI_PropertySet_Wrapper::dealloc (
     MI_PropertySet_Wrapper* pPropertySet =
         reinterpret_cast<MI_PropertySet_Wrapper*>(pSelf);
     pPropertySet->~MI_PropertySet_Wrapper ();
-    pPropertySet->ob_type->tp_free (pSelf);
+    Py_TYPE(pPropertySet)->tp_free (pSelf);
 }
 
 

--- a/python/mi_wrapper.hpp
+++ b/python/mi_wrapper.hpp
@@ -10,6 +10,7 @@
 #include "mi_value.hpp"
 #include "py_converter.hpp"
 #include "py_ptr.hpp"
+#include "python_compatibility.hpp"
 #include "shared.hpp"
 
 
@@ -597,7 +598,7 @@ MI_Wrapper<TYPE_ID>::dealloc (
     MI_Wrapper<TYPE_ID>* pWrapper =
         reinterpret_cast<MI_Wrapper<TYPE_ID>*>(pSelf);
     pWrapper->dtor ();
-    pWrapper->ob_type->tp_free (pSelf);
+    Py_TYPE(pWrapper)->tp_free (pSelf);
 }
 
 
@@ -890,7 +891,7 @@ MI_Array_Wrapper<TYPE_ID>::dealloc (
     MI_Array_Wrapper<TYPE_ID>* pArray =
         reinterpret_cast<MI_Array_Wrapper<TYPE_ID>*>(pSelf);
     pArray->dtor ();
-    pArray->ob_type->tp_free (pSelf);
+    Py_TYPE(pArray)->tp_free (pSelf);
 }
 
 
@@ -1452,7 +1453,7 @@ MI_Array_Iterator<TYPE_ID>::dealloc (
     MI_Array_Iterator<TYPE_ID>* pArray =
         reinterpret_cast<MI_Array_Iterator<TYPE_ID>*>(pObj);
     pArray->dtor ();
-    pArray->ob_type->tp_free (pObj);
+    Py_TYPE(pArray)->tp_free (pObj);
 }
 
 

--- a/python/omi_module.cpp
+++ b/python/omi_module.cpp
@@ -36,6 +36,12 @@ using namespace scx;
 extern "C" {
 
 
+#if PY_MAJOR_VERSION >= 3
+    // Python 3 requires the init function to be named PyInit_<module_name>
+    #define initomi PyInit_omi
+#endif
+
+
 PyMODINIT_FUNC
 initomi ()
 {
@@ -44,13 +50,35 @@ initomi ()
     get_BookEnd_global_methods (g_methods);
     PyMethodDef const sentinel = { NULL, NULL, 0, NULL };
     g_methods.push_back (sentinel);
-    PyObject* pModule =
-        Py_InitModule3 ("omi", &(g_methods[0]),
-                        "Module that creates the Foo extension type.");
+    PyObject* pModule;
+    const char* m_name = "omi";
+    const char* m_doc = "Module that creates the Foo extension type.";
+
+    #if PY_MAJOR_VERSION >= 3
+        static struct PyModuleDef moduledef = {
+            PyModuleDef_HEAD_INIT,
+            m_name,              /* m_name */
+            m_doc,               /* m_doc */
+            -1,                  /* m_size */
+            &(g_methods[0]),     /* m_methods */
+            NULL,                /* m_reload */
+            NULL,                /* m_traverse */
+            NULL,                /* m_clear */
+            NULL,                /* m_free */
+        };
+        pModule = PyModule_Create (&moduledef);
+    #else
+        pModule = Py_InitModule3 (m_name, &(g_methods[0]), m_doc);
+    #endif
 
     // classes
     init_BookEnd_wrapper (pModule);
     init_MI_wrapper (pModule);
+
+    #if PY_MAJOR_VERSION >= 3
+        // Python 3 should return the module
+        return pModule;
+    #endif
 }
 
 

--- a/python/py_converter.cpp
+++ b/python/py_converter.cpp
@@ -4,6 +4,7 @@
 
 
 #include "mi_wrapper.hpp"
+#include "python_compatibility.hpp"
 
 
 namespace

--- a/python/py_converter.hpp
+++ b/python/py_converter.hpp
@@ -43,6 +43,7 @@
 #include "debug_tags.hpp"
 #include "mi_type.hpp"
 #include "mi_value.hpp"
+#include "python_compatibility.hpp"
 #include "traits.hpp"
 
 

--- a/python/python_compatibility.hpp
+++ b/python/python_compatibility.hpp
@@ -1,0 +1,23 @@
+#ifndef INCLUDED_PYTHON_COMPATIBILITY_HPP
+#define INCLUDED_PYTHON_COMPATIBILITY_HPP
+
+
+#if PY_MAJOR_VERSION >= 3
+    // All the functions that returned Python int objects are now gone
+    // and wee need to replace them with the functions that returns
+    // Python long objects.
+    #define PyInt_FromLong PyLong_FromLong
+    #define PyInt_FromSize_t PyLong_FromSize_t
+    #define PyInt_FromSsize_t PyLong_FromSsize_t
+    #define PyInt_Check PyLong_Check
+    #define PyInt_AsLong PyLong_AsLong
+    #define PyInt_FromLong PyLong_FromLong
+
+    // Python 3 has now separate types for String, which doesn't exist anymore.
+    // The new types are PyBytes and PyUnicode.
+    #define PyString_AsString(x) PyBytes_AsString(PyUnicode_AsEncodedString(x, "utf-8", "strict"))
+    #define PyString_Check PyUnicode_Check
+    #define PyString_FromString PyUnicode_FromString
+#endif
+
+#endif // INCLUDED_PYTHON_COMPATIBILITY_HPP

--- a/python/shared.cpp
+++ b/python/shared.cpp
@@ -9,12 +9,12 @@
 void Zero_PyTypeObject (PyTypeObject* pObjOut)
 {
     PyTypeObject const OBJ = {
-        PyObject_HEAD_INIT (NULL)
+        // Works on both Python 2 and Python 3, ob_size is the second argument
+        PyVarObject_HEAD_INIT(NULL, 0)
     };
     if (NULL != pObjOut)
     {
         memcpy (pObjOut, &OBJ, sizeof (PyTypeObject));
-        pObjOut->ob_size = 0;
         pObjOut->tp_name = NULL;
         pObjOut->tp_basicsize = 0;
         pObjOut->tp_itemsize = 0;
@@ -22,7 +22,16 @@ void Zero_PyTypeObject (PyTypeObject* pObjOut)
         pObjOut->tp_print = NULL;
         pObjOut->tp_getattr = NULL;
         pObjOut->tp_setattr = NULL;
-        pObjOut->tp_compare = NULL;
+        #if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION > 4
+            // Called tp_as_sync in Python 3 ( > 3.4)
+            pObjOut->tp_as_sync = NULL;
+        #elif PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION <= 4
+            // Called tp_reserved in Python 3 (3 - 3.4)
+            pObjOut->tp_reserved = NULL;
+        #else
+            // Called tp_compare in Python 2 ( < 3)
+            pObjOut->tp_compare = NULL;
+        #endif
         pObjOut->tp_repr = NULL;
         pObjOut->tp_as_number = NULL;
         pObjOut->tp_as_sequence = NULL;


### PR DESCRIPTION
1. We can no longer pick the ob_type directly from the
struct, so code like ob->ob_type stops working.
We should replace this with Py_TYPE(ob). The Py_TYPE macro is
supported starting with Python 2.6.

2. Python 3 has now separate types for String, which doesn't
exist anymore. The new types are PyBytes and PyUnicode. We
will replace all usages of PyString with PyUnicode.

3. The family of functions to initialize modules, such as
Py_InitModule3 are gone. Instead, we should use PyModule_Create.

4. Zero_PyTypeObject tries to use the field tp_compare which is
specific to Python 2. On Python 3 is called tp_reserved (<= Python 3.4)
and tp_as_sync ( > Python 3.4).

5. The function which initializes the module changed in Python 3.
In Python 2 was:
  PyMODINIT_FUNC init<yourmodulename>(void)
and in Python 3 is:
  PyMODINIT_FUNC PyInit_<yourmodulename>(void)
We will use a macro to replace the init function name.

6. Using only METH_KEYWORDS will land you with a SystemError that
complains about METH_OLDARGS on Python 3. Note that we can use
METH_VARARGS | METH_KEYWORDS which is equivalent to METH_KEYWORDS
and works on Python 2 and Python 3.