### PR TITLE
fix XYZ_Number issue in private build

### DIFF
--- a/samples/xyz_number/mi_main.py
+++ b/samples/xyz_number/mi_main.py
@@ -28,8 +28,8 @@ def XYZ_Number_EnumerateInstances (
     instance.SetValue ('Description',
                        MI_String ('This is a long long long long string'))
     for i in range (1000):
-        instance.SetValue ('Number', i)
-        instance.SetValue ('NumberString', i.str ())
+        instance.SetValue ('Number', MI_Uint32 (i))
+        instance.SetValue ('NumberString', MI_String (str (i)))
         context.PostInstance (instance)
     context.PostResult (MI_RESULT_OK)
 


### PR DESCRIPTION
I tried XYZ_Number in private build, following script doesn't support:
```
        instance.SetValue ('Number', i)
        instance.SetValue ('NumberString', i.str ())
```
And get following error:
```
~/samples/xyz_number
root@py64-cent7-03  # /opt/omi/bin/omicli ei root/cimv2 XYZ_Number
/opt/omi/bin/omicli: result: MI_RESULT_FAILED
/opt/omi/bin/omicli: result: A general error occurred, not covered by a more specific error code.
instance of OMI_Error
{
    OwningEntity=OMI:CIMOM
    MessageID=OMI:MI_Result:1
    Message=A general error occurred, not covered by a more specific error code.
    MessageArguments={}
    PerceivedSeverity=7
    ProbableCause=0
    ProbableCauseDescription=Unknown
    CIMStatusCode=1
    OMI_Code=1
    OMI_Category=0
    OMI_Type=MI
    OMI_ErrorMessage=A general error occurred, not covered by a more specific error code.
}
```
From log:/var/opt/omi/log/omiagent.root.root.log , it get error:
```
2017/09/24 23:21:45 [21304,21304] WARNING: null(0): EventId=30056 Priority=WARNING failed to call library unload: 1:XYZ_Number 
```