### PR TITLE
Add runtime library dir for omi python module

### DIFF
--- a/python/omi_setup.py
+++ b/python/omi_setup.py
@@ -33,9 +33,10 @@ module1 = Extension (
                     root_dir + '/omi/Unix/output/include',
                     root_dir + '/omi/Unix/common'],
     library_dirs = [root_dir + '/scriptprovider/bin'],
-    
+
     runtime_library_dirs = [root_dir + '/scriptprovider/bin',
-                            lib_dir],
+                            lib_dir,
+                            '/opt/omi/lib'],
 
     libraries = ['OMIScriptProvider'],
     define_macros = [('PRINT_BOOKENDS','0')],


### PR DESCRIPTION
Currently, when the omi python module is built, the path to where
it can find libOMIScriptProvider.so is not added to runtime_library_dirs.

This results in having an import error when using the installer packages.

To fix this, '/opt/omi/lib' was added to runtime_library_dirs when building
the omi python module.

Closes issue #11 