### PR TITLE
Skip creating directories during package install

### DIFF
--- a/installbuilder/Base_OMIScriptProvider.data
+++ b/installbuilder/Base_OMIScriptProvider.data
@@ -18,8 +18,8 @@ SHLIB_EXT: 'so'
 
 %Directories
 /opt/omi/;      755; root; root; sysdir
-/opt/omi/lib;   755; root; root;
-/opt/omi/bin;   755; root; root;
+/opt/omi/lib;   755; root; root; sysdir
+/opt/omi/bin;   755; root; root; sysdir
 
 
 %Links


### PR DESCRIPTION
At the moment the OMI Script Provider will try to
create the folders '/opt/omi/lib/ and '/opt/omi/bin'
during package install.

OMI is already creating those directories, resulting
in an error when the RPM package is getting installed.

Since OMI is a requirement for the OMI Script Provider,
we can assume that the folders already exist on the system
and we will not try to create the directories when installing
the package.

Closes issue #35 