### PR TITLE
Change architecture detection flag from -p to -m

### DIFF
--- a/installbuilder/GNUmakefile
+++ b/installbuilder/GNUmakefile
@@ -7,8 +7,8 @@ RELEASE_DIR:=$(OSP_OUTPUTDIR)/release
 
 IB_DIR:=$(TOP)/pal/installer/InstallBuilder
 
-UNAME_P:=$(shell uname -p)
-ifeq ($(UNAME_P),x86_64)
+UNAME_M:=$(shell uname -m)
+ifeq ($(UNAME_M),x86_64)
  PF_ARCH := x64
 else
  PF_ARCH := x86


### PR DESCRIPTION
In order to detect the architecture type, uname is being used.
It is given '-p' argument which according to the man page,
it will print the processor type or "unknown" in case it is not
known.

This will print "unknown" on Debian 7, while on Ubuntu platforms
it works correctly printing the architecture type.

Changing the flag to -m will make uname always print the architecture
type on all the systems.