### PR TITLE
Fix for issue #44. This also depends on PR #427 in OMI.

### DIFF
--- a/omigen_py/GNUmakefile
+++ b/omigen_py/GNUmakefile
@@ -64,6 +64,7 @@ LIBS+=$(shell $(BUILDTOOL) syslibs)
 
 
 CPPFLAGS+=$(INCLUDES)
+CPPFLAGS+=-fpermissive
 
 
 # compile rule

--- a/provider/GNUmakefile
+++ b/provider/GNUmakefile
@@ -27,7 +27,12 @@ $(BIN_PATH)/$(LIBRARY) :
 INCLUDE_PATH+=$(INCDIR)
 
 
+PRINT_BOOKENDS?=0
+
+
+CPPFLAGS+=-DPRINT_BOOKENDS=$(PRINT_BOOKENDS)
 CPPFLAGS+=$(addprefix -I,$(INCLUDE_PATH))
+CPPFLAGS+=-fpermissive
 
 
 SOURCES:=client.cpp
@@ -38,6 +43,7 @@ SOURCES+=mi_instance.cpp
 SOURCES+=mi_main.cpp
 SOURCES+=mi_memory_helper.cpp
 SOURCES+=mi_module.cpp
+SOURCES+=mi_module_self.cpp
 SOURCES+=mi_schema.cpp
 SOURCES+=mi_script_extensions.cpp
 SOURCES+=mi_value.cpp

--- a/provider/client.hpp
+++ b/provider/client.hpp
@@ -5,9 +5,6 @@
 
 
 #include "internal_counted_ptr.hpp"
-#include "mi_context.hpp"
-#include "mi_module.hpp"
-#include "socket_wrapper.hpp"
 
 
 #include <cstdlib>
@@ -16,8 +13,15 @@
 #define EXPORT_PUBLIC __attribute__ ((visibility ("default")))
 
 
+class socket_wrapper;
+
+
 namespace scx
 {
+
+
+class MI_Context;
+class MI_Module;
 
 
 class Client : public util::ref_counted_obj
@@ -29,14 +33,20 @@ public:
         SUCCESS = EXIT_SUCCESS,
     };
 
-    EXPORT_PUBLIC /*ctor*/ Client (
-        socket_wrapper::Ptr const& pSocket,
-        MI_Module::Ptr const& pModule);
+    EXPORT_PUBLIC static int create (
+        unsigned short const& port,
+        unsigned int (&key)[4],
+        util::internal_counted_ptr<MI_Module> const& pModule,
+        Ptr* ppClientOut);
     EXPORT_PUBLIC virtual /*dtor*/ ~Client ();
 
     EXPORT_PUBLIC int run ();
 
 private:
+    /*ctor*/ Client (
+        util::internal_counted_ptr<socket_wrapper> const& pSocket,
+        util::internal_counted_ptr<MI_Module> const& pModule);
+
     int handle_module_load ();
     int handle_module_unload ();
     int handle_class_load ();
@@ -52,9 +62,9 @@ private:
     /*ctor*/ Client (Client const&); // = delete
     Client& operator = (Client const&); // = delete
     
-    socket_wrapper::Ptr const m_pSocket;
-    MI_Module::Ptr const m_pModule;
-    MI_Context::Ptr const m_pContext;
+    util::internal_counted_ptr<socket_wrapper> const m_pSocket;
+    util::internal_counted_ptr<MI_Module> const m_pModule;
+    util::internal_counted_ptr<MI_Context> const m_pContext;
 };
 
 

--- a/provider/mi_module_self.cpp
+++ b/provider/mi_module_self.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT license.
+#include "mi_module_self.hpp"
+
+
+#include "debug_tags.hpp"
+#include "server.hpp"
+
+
+#include <sstream>
+
+
+/*ctor*/
+_MI_Module_Self::_MI_Module_Self (
+    std::string const& module_name)
+    : ModuleName (module_name)
+{
+#if (PRINT_BOOKENDS)
+    std::ostringstream strm;
+    strm << " ModuleName=\"" << ModuleName << "\"";
+    SCX_BOOKEND_EX ("_MI_Module_Self::ctor", strm.str ().c_str ());
+#endif
+}
+
+
+/*dtor*/
+_MI_Module_Self::~_MI_Module_Self ()
+{
+#if (PRINT_BOOKENDS)
+    std::ostringstream strm;
+    strm << " ModuleName=\" << ModuleName << \"";
+    SCX_BOOKEND_EX ("_MI_Module_Self::dtor", strm.str ().c_str ());
+#endif
+}

--- a/provider/mi_module_self.hpp
+++ b/provider/mi_module_self.hpp
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT license.
+#ifndef INCLUDED_MI_MODULE_SELF_HPP
+#define INCLUDED_MI_MODULE_SELF_HPP
+
+
+#include "unique_ptr.hpp"
+
+
+#include <MI.h>
+#include <string>
+
+
+class Server;
+
+
+struct _MI_Module_Self
+{
+    /*ctor*/ _MI_Module_Self (std::string const& module_name);
+    /*dtor*/ ~_MI_Module_Self ();
+
+    std::string ModuleName;
+    util::unique_ptr<Server> pServer;
+    MI_Module Module;
+};
+
+
+#endif // INCLUDED_MI_MODULE_SELF_HPP

--- a/provider/server.hpp
+++ b/provider/server.hpp
@@ -31,7 +31,8 @@ public:
     {
         SUCCESS = EXIT_SUCCESS,
         INVALID_STATE,
-        SOCKETPAIR_FAILED,
+        LISTEN_SOCKET_FAILED,
+        CLIENT_FAILED_TO_CONNECT,
         FORK_FAILED,
         SEND_FAILED,
         INVALID_PARAM,
@@ -126,6 +127,7 @@ public:
         MI_Instance const* pInputParameters);
 
 private:
+    int init ();
 
     /*ctor*/ Server (Server const&); // delete
     Server& operator = (Server const&); // delete

--- a/python/client.py
+++ b/python/client.py
@@ -12,11 +12,11 @@ def main (argv = None):
     be = BookEnd ('main')
     for i in range (len (argv)):
         BookEndPrint ('args[' + str (i) + ']: "' + argv[i] + '"')
-    if len (argv) == 3:
+    if len (argv) == 4:
         try:
-            fd = int (argv[1])
-            path = os.path.split (os.path.realpath (argv[0]))[0] + '/' + argv[2]
-            client = Client (fd, path)
+            path = os.path.split (os.path.realpath (argv[0]))[0] + '/' + argv[1]
+            port = int (argv[2])
+            client = Client (path, port, argv[3])
             client.run ()
         except:
             e = sys.exc_info ()[0]

--- a/python/omi_setup.py
+++ b/python/omi_setup.py
@@ -39,7 +39,7 @@ module1 = Extension (
                             '/opt/omi/lib'],
 
     libraries = ['OMIScriptProvider'],
-    define_macros = [],
+    define_macros = [('PRINT_BOOKENDS','0')],
     
     extra_link_args = [
         '-Wl,-R' + root_dir + '/scriptprovider/output/bin',

--- a/test/GNUmakefile
+++ b/test/GNUmakefile
@@ -64,7 +64,9 @@ LIBS+=-lOMIScriptProvider
 LIBS+=-lbase
 LIBS+=-lpal
 
+
 CPPFLAGS+=$(INCLUDES)
+CPPFLAGS+=-fpermissive
 
 
 # compile rule


### PR DESCRIPTION
The Script Provider uses the same shared library for every provider. There are some global variables that were being reassigned at run time when multiple providers where run concurrently. This would cause errors is provider A was queried, then provider B was queried, and then provider A again before provider A had unloaded. I changed the signature of the start fn that OMI calls to use a member of OMI to store this instead of using a global variable in the provider.
This also changes from using AF_UNIX sockets to AF_INET sockets.