### PR TITLE
Fix setting 0 value for real numbers

### DIFF
--- a/python/py_converter.hpp
+++ b/python/py_converter.hpp
@@ -421,8 +421,9 @@ PyConverter_Real<T>::fromPyObject (
     if (PyFloat_Check (pSource))
     {
         double value = PyFloat_AS_DOUBLE (pSource);
-        if (MI_Limits<Type_to_ID<T>::ID>::min () <= fabs (value) &&
-            MI_Limits<Type_to_ID<T>::ID>::max () >= fabs (value))
+        if ((MI_Limits<Type_to_ID<T>::ID>::min () <= fabs (value) &&
+             MI_Limits<Type_to_ID<T>::ID>::max () >= fabs (value)) ||
+             (0.0 == fabs (value)))
         {
             *pValueOut = static_cast<T>(value);
             rval = PY_SUCCESS;


### PR DESCRIPTION
For real numbers, the given value is checked
to be between DBL_MIN and DBL_MAX.

However, DBL_MIN is actually the smallest absolute
value representable, which is greater than 0.0 and
this will be interpreted as out of range.

Adding a case to check for 0.0 before checking the
actual limits fixes the issue.

Closes issue: #60 