### PR TITLE
Fix typo for PyObject function for Python >3.4

### DIFF
--- a/python/shared.cpp
+++ b/python/shared.cpp
@@ -23,8 +23,8 @@ void Zero_PyTypeObject (PyTypeObject* pObjOut)
         pObjOut->tp_getattr = NULL;
         pObjOut->tp_setattr = NULL;
         #if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION > 4
-            // Called tp_as_sync in Python 3 ( > 3.4)
-            pObjOut->tp_as_sync = NULL;
+            // Called tp_as_async in Python 3 ( > 3.4)
+            pObjOut->tp_as_async = NULL;
         #elif PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION <= 4
             // Called tp_reserved in Python 3 (3 - 3.4)
             pObjOut->tp_reserved = NULL;


### PR DESCRIPTION
Type in the function name, it's ```tp_as_async``` not ```tp_as_sync```.
Official documentation here: https://docs.python.org/3/c-api/typeobj.html