### PR TITLE
Fix for issue #66.  CreateInstance and remoting.

### DIFF
--- a/provider/server.cpp
+++ b/provider/server.cpp
@@ -1034,26 +1034,12 @@ Server::CreateInstance (
             socket_wrapper::SUCCESS == (
                 rval = protocol::send (*pNewInstance, *m_pSocket)))
         {
-            protocol::opcode_t opcode;
-            rval = protocol::recv_opcode (&opcode, *m_pSocket);
-            if (socket_wrapper::SUCCESS == rval)
+            SCX_BOOKEND ("send succeeded");
+            rval = handle_return (pContext, m_pSchemaDecl.get (), NULL,
+                                  *m_pSocket);
+            if (SUCCESS != rval)
             {
-                if (protocol::POST_RESULT == opcode)
-                {
-                    SCX_BOOKEND_PRINT ("rec'ved POST_RESULT");
-                    rval = handle_post_result (pContext, *m_pSocket);
-                }
-                else
-                {
-                    SCX_BOOKEND_PRINT ("rec'd unhandled opcode");
-                    // todo: error
-                }
-            }
-            else
-            {
-                SCX_BOOKEND_PRINT ("socket error");
-                // socket error
-                // todo: error
+                MI_Context_PostResult (pContext, MI_RESULT_FAILED);
             }
         }
         if (SUCCESS != rval)

--- a/samples/hosts/_mi_main.py
+++ b/samples/hosts/_mi_main.py
@@ -103,6 +103,7 @@ def Hosts_CreateInstance (
                     fqdn.value + '\n')
         fout.close ()
         os.rename (TEMP_HOST_FILE_NAME, HOST_FILE_NAME)
+        context.PostInstance (instance)
         context.PostResult (MI_RESULT_OK)
     else:
         fout.close ()


### PR DESCRIPTION
CreateInstance needs to PostInstance in order to suppress and error in the remoting code.  This also applies to issue #65.

This change adds support calling PostInstance from CreateInstance.  CreateInstance will still work without error (expect when remoting) without calling PostInstance.
Jumping, I tested remoting on a single box.  Would you please test this solution across boxes?
I also ran remoting with ei, di, gi, and mi.  Those all seem to work correctly when remoting without modification.