### PR TITLE
Fix memory leaks Python >= 3

### DIFF
--- a/python/client_wrapper.cpp
+++ b/python/client_wrapper.cpp
@@ -177,7 +177,13 @@ Client_Wrapper::init (
                  ++i)
             {
                 PyObject* pPathItem = PyList_GET_ITEM (pSysPath, i);
-                strm << "    " << PyString_AsString (pPathItem);
+                #if PY_MAJOR_VERSION >= 3
+                    PyObject* tmp = PyUnicode_AsEncodedString (pPathItem, "utf-8", "strict");
+                    strm << "    " << PyBytes_AsString (tmp);
+                    Py_DECREF(tmp);
+                #else
+                    strm << "    " << PyString_AsString (pPathItem);
+                #endif
                 CLIENT_INIT_BOOKEND_PRINT (strm.str ().c_str ());
             }
         }

--- a/python/py_converter.cpp
+++ b/python/py_converter.cpp
@@ -479,7 +479,13 @@ PyConverter<MI_Type<MI_STRING>::type_t>::fromPyObject (
     assert (NULL != pValueOut);
     if (PyString_Check (pSource))
     {
-        *pValueOut = PyString_AsString (pSource);
+        #if PY_MAJOR_VERSION >= 3
+            PyObject* tmp = PyUnicode_AsEncodedString (pSource, "utf-8", "strict");
+            *pValueOut = PyBytes_AsString (tmp);
+            Py_DECREF(tmp);
+        #else
+            *pValueOut = PyString_AsString (pSource);
+        #endif
         rval = PY_SUCCESS;
     }
     else

--- a/python/python_compatibility.hpp
+++ b/python/python_compatibility.hpp
@@ -15,7 +15,14 @@
 
     // Python 3 has now separate types for String, which doesn't exist anymore.
     // The new types are PyBytes and PyUnicode.
-    #define PyString_AsString(x) PyBytes_AsString(PyUnicode_AsEncodedString(x, "utf-8", "strict"))
+    // Using the following line will cause a memory leak on Python 3.
+    // PyUnicode_AsEncodedString returns a new reference which needs to be
+    // freed after the conversion
+    // #define PyString_AsString(x) PyBytes_AsString(PyUnicode_AsEncodedString(x, "utf-8", "strict"))
+    // Correct version to be used in the code:
+    // PyObject* tmp = PyUnicode_AsEncodedString(x, "utf-8", "strict");
+    // result = PyBytes_AsString(tmp);
+    // Py_DECREF(tmp);
     #define PyString_Check PyUnicode_Check
     #define PyString_FromString PyUnicode_FromString
 #endif


### PR DESCRIPTION
PyUnicode_AsEncodedString returns a new reference on which we need
to call Py_DECREF after the call to PyBytes_AsString.

To fix this, the macro for PyString_AsString has been removed.
All the usages of that function have been replaced with the correct
one that also frees the object created.