### PR TITLE
Pen Test changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,5 @@ python/lib
 output/
 
 # changes should be made on the templates for those files
-/GNUmakefile
-/provider/GNUmakefile
 /python/client.py
 /installbuilder/Base_OMIScriptProvider.data

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,8 +14,8 @@ SCRIPTPROVIDER :
 
 .phony : PYTHONWRAPPER
 PYTHONWRAPPER :
-	cd $(TOP)/scriptprovider/python && __PYTHON_VERSION__ omi_setup.py build \
-		--build-temp $(OSP_OUTPUTDIR)/python/build
+	cd $(TOP)/scriptprovider/python && $(CONFIG_PYTHON_NAME) omi_setup.py \
+       build --build-temp $(OSP_OUTPUTDIR)/python/build
 
 
 .phony : OMIGEN_PY
@@ -33,7 +33,7 @@ TEST :
 .phony : clean
 clean :
 	$(MAKE) -C $(TOP)/scriptprovider/provider clean
-	cd $(TOP)/scriptprovider/python && __PYTHON_VERSION__ omi_setup.py clean
+	cd $(TOP)/scriptprovider/python && $(CONFIG_PYTHON_NAME) omi_setup.py clean
 	$(MAKE) -C $(TOP)/scriptprovider/omigen_py clean
 	$(MAKE) -C $(TOP)/scriptprovider/test clean
 
@@ -41,7 +41,8 @@ clean :
 .phony : install
 install :
 	$(MAKE) -C $(TOP)/scriptprovider/provider install
-	cd $(TOP)/scriptprovider/python && __PYTHON_VERSION__ omi_setup.py install
+	cd $(TOP)/scriptprovider/python && $(CONFIG_PYTHON_NAME) omi_setup.py \
+       install
 	$(MAKE) -C $(TOP)/scriptprovider/omigen_py install
 
 

--- a/configure
+++ b/configure
@@ -140,10 +140,8 @@ if [ $? != 0 ]; then
 fi
 
 files_to_update="
-    $root/provider/GNUmakefile-template
     $root/python/client.py-template
     $root/installbuilder/Base_OMIScriptProvider.data-template
-    $root/GNUmakefile-template
 "
 for file in $files_to_update
 do
@@ -207,6 +205,7 @@ CONFIG_REVISION=$revision
 CONFIG_OMI_SCRIPTPROVIDER_VERSION_BUILD=$patch_level
 CONFIG_DATE=$date
 CONFIG_PYTHON_VERSION=$pythonversion
+CONFIG_PYTHON_NAME=$python_name
 
 CONFIG_MAK=1
 

--- a/provider/GNUmakefile
+++ b/provider/GNUmakefile
@@ -59,6 +59,9 @@ OBJECTS:=$(addprefix $(OBJ_PATH)/,$(SOURCES:.cpp=.o))
 $(OBJECTS) : | $(OBJ_PATH)
 
 
+LIBS+=-lcrypto
+
+
 CPPFLAGS+=$(INCLUDES)
 
 
@@ -76,7 +79,7 @@ $(OBJ_PATH)/%.o : %.cpp
 $(BIN_PATH)/$(LIBRARY) : \
 	$(OBJECTS) | $(BIN_PATH)
 	@echo ...linking: $(LIBRARY)
-	$(CXX) -shared -o $@ $^
+	$(CXX) -shared -o $@ $^ $(LIBS)
 
 
 # a rule to make root bin directory
@@ -93,10 +96,10 @@ install : $(BIN_PATH)/$(LIBRARY)
 	@echo ...installing: $(LIBRARY)
 	@$(COPY) $(BIN_PATH)/$(LIBRARY) $(CONFIG_LIBDIR)/$(LIBRARY)
 	@grep -cq '^\W*script=\-\-Python:' $(CONFIG_SYSCONFDIR)/omireg.conf || \
-		echo 'script=--Python:__PYTHON_VERSION__:client.py' >> \
+		echo 'script=--Python:$(CONFIG_PYTHON_NAME):client.py' >> \
 		$(CONFIG_SYSCONFDIR)/omireg.conf
 	@grep -cq '^\W*script=\-\-python:' $(CONFIG_SYSCONFDIR)/omireg.conf || \
-		echo 'script=--python:__PYTHON_VERSION__:client.py' >> \
+		echo 'script=--python:$(CONFIG_PYTHON_NAME):client.py' >> \
 		$(CONFIG_SYSCONFDIR)/omireg.conf
 
 

--- a/provider/server.cpp
+++ b/provider/server.cpp
@@ -11,6 +11,7 @@
 #include "unique_ptr.hpp"
 
 
+//#include <base/credcache.h>
 #include <cassert>
 #include <cctype>
 #include <config.h>
@@ -18,6 +19,7 @@
 #include <fcntl.h>
 #include <list>
 #include <netinet/in.h>
+#include <openssl/rand.h>
 #include <sstream>
 #include <sys/select.h>
 #include <sys/socket.h>
@@ -252,14 +254,17 @@ void
 generate_key (
     unsigned int (&key)[4])
 {
-    srand (time (0));
-    for (int i = 0; i < 4; ++i)
+    if (1 != RAND_bytes (reinterpret_cast<unsigned char*>(key), sizeof (key)))
     {
-        key[i] = 0;
-        for (int j = 0; j < 4; ++j)
+        srand (time (0));
+        for (int i = 0; i < 4; ++i)
         {
-            key[i] |= static_cast<unsigned int>(
-                static_cast<unsigned char> (rand () % 0xff) << (8 * j));
+            key[i] = 0;
+            for (int j = 0; j < 4; ++j)
+            {
+                key[i] |= static_cast<unsigned int>(
+                    static_cast<unsigned char> (rand () % 0xff) << (8 * j));
+            }
         }
     }
 }
@@ -286,29 +291,36 @@ create_listener (
             sockaddr_in addr;
             memset (&addr, 0, sizeof (addr));
             addr.sin_family = AF_INET;
-            addr.sin_addr.s_addr = INADDR_ANY;
-            unsigned short port = 5999;
-            int local_result;
-            do
-            {
-                ++port;
-                addr.sin_port = htons (port);
-                local_result =
-                    bind (listener_fd, reinterpret_cast<sockaddr*>(&addr),
-                          sizeof (addr));
-            } while (-1 == local_result &&
-                     EADDRINUSE == errno);
+            addr.sin_addr.s_addr = htonl (INADDR_LOOPBACK);
+            addr.sin_port = htons (0);
+            int local_result =
+                bind (listener_fd, reinterpret_cast<sockaddr*>(&addr),
+                      sizeof (addr));
             if (0 == local_result)
             {
                 local_result = listen (listener_fd, 5);
                 if (0 == local_result)
                 {
-                    *pPortOut = port;
-                    *pListenerFDOut = listener_fd;
-                    listener_holder.release ();
-                    result = Server::SUCCESS;
-                }
+                    socklen_t addrlen = sizeof (addr);
+                    local_result =
+                        getsockname (listener_fd,
+                                     reinterpret_cast<sockaddr*>(&addr),
+                                     &addrlen);
+                    if (0 == local_result)
+                    {
+                        *pPortOut = ntohs (addr.sin_port);
+                        *pListenerFDOut = listener_fd;
+                        listener_holder.release ();
+                        result = Server::SUCCESS;
+                    }
 #if (PRINT_BOOKENDS)
+                    else
+                    {
+                        std::ostringstream strm;
+                        strm << "getsockname failed: " << errnoText;
+                        SCX_BOOKEND_PRINT (strm.str ().c_str ());
+                    }
+                }
                 else
                 {
                     std::ostringstream strm;
@@ -337,6 +349,7 @@ create_listener (
         SCX_BOOKEND_PRINT (strm.str ().c_str ());
     }
 #else // PRINT_BOOKENDS
+                }
             }
         }
     }

--- a/test/GNUmakefile
+++ b/test/GNUmakefile
@@ -59,10 +59,13 @@ $(OBJECTS) : | $(OBJ_PATH)
 
 LDFLAGS+=-L$(BIN_PATH)
 LDFLAGS+=-L$(LIBDIR)
+LDFLAGS+=-L$(OPENSSLLIBDIR)
 LDFLAGS+=-Wl,-R/$(BIN_PATH)
 LIBS+=-lOMIScriptProvider
 LIBS+=-lbase
 LIBS+=-lpal
+LIBS+=-lcrypto
+
 
 CPPFLAGS+=$(INCLUDES)
 


### PR DESCRIPTION
Limit incoming sockets to only accept LOOPBACK.
Using randomly assigned port number.
Using openssl random number for key.
Changed provider/GNUmakefile and GNUmakefile to use a variable for python version instead of doing a sed/awk copy.